### PR TITLE
Close #ADIBLO-8996 support syslogger

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    request_headers_logger (0.0.3)
+    request_headers_logger (0.0.4)
       request_headers_middleware (~> 0.0.4)
 
 GEM

--- a/lib/request_headers_logger/message_queue/message_queue_plugin.rb
+++ b/lib/request_headers_logger/message_queue/message_queue_plugin.rb
@@ -22,7 +22,7 @@ module RequestHeadersLogger
       end
 
       lifecycle.before(:consume) do |delivery_info, properties, payload|
-        store = symbolize(properties.headers).dig(:store) || {}
+        store = symbolize(properties.headers)&.dig(:store) || {}
         RequestHeadersMiddleware.store = store
 
         set_mq_loggers

--- a/lib/request_headers_logger/text_formatter.rb
+++ b/lib/request_headers_logger/text_formatter.rb
@@ -6,12 +6,17 @@ module RequestHeadersLogger
   module TextFormatter
     def call(severity, time, progname, msg)
       format(::Logger::Formatter::Format,
-             severity[0..0],
+             severity_name(severity)[0],
              format_datetime(time),
              $PID,
-             severity,
+             severity_name(severity),
              progname,
              msg2str("#{tags_text}#{msg}"))
+    end
+
+    def severity_name(severity)
+      return Logger::Severity.constants[severity].to_s if severity.is_a?(Integer)
+      severity
     end
 
     def tags_text

--- a/lib/request_headers_logger/version.rb
+++ b/lib/request_headers_logger/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RequestHeadersLogger
-  VERSION = '0.0.3'
+  VERSION = '0.0.4'
 end


### PR DESCRIPTION
syslogger is passing the severity as an Integer an not as a string, so we cant use the range.

```
➜  ~/personal/request_headers_logger  (ADIBLO-8996-support-syslog-logger ✔ ): irb                                                                                                                                                                                                                                                                                         (2.3.3)
2.3.3 :001 > 1[0..2]
TypeError: no implicit conversion of Range into Integer
	from (irb):1:in `[]'
	from (irb):1
	from /Users/shihadeh/.rvm/rubies/ruby-2.3.3/bin/irb:11:in `<main>'
2.3.3 :002 > 1[0]
 => 1
2.3.3 :003 >
```


@tonchev-ivan 